### PR TITLE
Replace struct with serializer

### DIFF
--- a/spec/statsd/metric_message_spec.cr
+++ b/spec/statsd/metric_message_spec.cr
@@ -3,54 +3,40 @@ require "../spec_helper"
 describe Statsd::MetricMessage do
   context "base protocol" do
     it "supports #gauge" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("users.current", 20, "g")
-      message.to_s(io)
-      io.to_s.should eq("users.current:20|g")
+      message = Statsd::MetricMessage.serialize_metric("users.current", 20, "g")
+      message.should eq("users.current:20|g")
     end
 
     it "supports #counter (Int32)" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("page.views", 1, "c")
-      message.to_s(io)
-      io.to_s.should eq("page.views:1|c")
+      message = Statsd::MetricMessage.serialize_metric("page.views", 1, "c")
+      message.should eq("page.views:1|c")
     end
 
     it "supports #counter (Float)" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("page.views", 1.3, "c")
-      message.to_s(io)
-      io.to_s.should eq("page.views:1.3|c")
+      message = Statsd::MetricMessage.serialize_metric("page.views", 1.3, "c")
+      message.should eq("page.views:1.3|c")
     end
 
     it "supports #counter, @sampled (Int32)" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("page.views", 1, "c", 0.5)
-      message.to_s(io)
-      io.to_s.should eq("page.views:1|c|@0.5")
+      message = Statsd::MetricMessage.serialize_metric("page.views", 1, "c", 0.5)
+      message.should eq("page.views:1|c|@0.5")
     end
 
     it "supports #counter, @sampled (Float)" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("page.views", 1.3, "c", 0.3)
-      message.to_s(io)
-      io.to_s.should eq("page.views:1.3|c|@0.3")
+      message = Statsd::MetricMessage.serialize_metric("page.views", 1.3, "c", 0.3)
+      message.should eq("page.views:1.3|c|@0.3")
     end
   end
 
   context "extended protocol: tags" do
     it "supports #gauge, @tag" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("users.current", 20, "g", tags: ["app:foo"])
-      message.to_s(io)
-      io.to_s.should eq("users.current:20|g|#app:foo")
+      message = Statsd::MetricMessage.serialize_metric("users.current", 20, "g", tags: ["app:foo"])
+      message.should eq("users.current:20|g|#app:foo")
     end
 
     it "supports #gauge, @tags" do
-      io = MemoryIO.new
-      message = Statsd::MetricMessage.new("users.current", 20, "g", tags: ["app:foo", "host:bar"])
-      message.to_s(io)
-      io.to_s.should eq("users.current:20|g|#app:foo,host:bar")
+      message = Statsd::MetricMessage.serialize_metric("users.current", 20, "g", tags: ["app:foo", "host:bar"])
+      message.should eq("users.current:20|g|#app:foo,host:bar")
     end
   end
 end

--- a/src/statsd/client.cr
+++ b/src/statsd/client.cr
@@ -25,16 +25,15 @@ module Statsd
     end
 
     private def send_metric(name, value, metric_type, sample_rate = nil, tags = nil)
-      message = MetricMessage.new(
+      message = MetricMessage.serialize_metric(
         name,
         value,
         metric_type,
         sample_rate,
-        tags,
-      )
+        tags)
 
       begin
-        @client.send(message.to_s, @destination)
+        @client.send(message, @destination)
       rescue ex : Errno
         if ex.errno == Errno::ECONNREFUSED
           # TODO: add a debug log event here if this occurs

--- a/src/statsd/metric_message.cr
+++ b/src/statsd/metric_message.cr
@@ -1,31 +1,25 @@
 module Statsd
-  struct MetricMessage
-    def initialize(
-      @name : String,
-      # TODO: replace with Number::Primitive in release post-0.16.0
-      @value : Int::Primitive | Float::Primitive,
-      @metric_type : String,
-      @sample_rate : Int::Primitive | Float::Primitive | Nil = nil,
-      @tags : Array(String)? = nil,
-    )
-    end
-
-    # Convert the MetricMessage to a Datagram-formatted String
+  module MetricMessage
+    # Serialize the MetricMessage to a Datagram-formatted String
     #
     # Examples of valid datagrams format combinations:
-    # ```
     # metric.name:value|type
     # metric.name:value|type|@sample_rate
     # metric.name:value|type|#tag1:value,tag2
     # metric.name:value|type|@sample_rate|#tag1:value,tag2:value
-    # ```
-    def to_s(io : IO)
-      io << @name << ":" << @value << "|" << @metric_type
 
-      io << "|@" << @sample_rate if @sample_rate
-
-      if tags = @tags
-        io << "|#" << tags.join(",")
+    # :nodoc:
+    def self.serialize_metric(
+                              name : String,
+                              # TODO: replace with Number::Primitive in release post-0.16.0
+                              value : Int::Primitive | Float::Primitive,
+                              metric_type : String,
+                              sample_rate : Int::Primitive | Float::Primitive | Nil = nil,
+                              tags : Array(String)? = nil)
+      String.build do |io|
+        io << name << ":" << value << "|" << metric_type
+        io << "|@" << sample_rate if sample_rate
+        io << "|#" << tags.join(",") if tags
       end
     end
   end


### PR DESCRIPTION
Instead of creating a struct per message, use a method to build the
string and pass it back to the Client to emit.

Applies `crystal tool format` rules.
