### PR TITLE
:sparkles: Emit timing from a block even if raised

### DIFF
--- a/spec/statsd/methods_spec.cr
+++ b/spec/statsd/methods_spec.cr
@@ -154,6 +154,14 @@ describe Statsd::Methods do
         server.gets(expected_message.bytesize).should eq expected_message
       end
 
+      it "should emit a timing even if the block raises" do
+        expect_raises do
+          statsd.time("foobar", tags: ["foo:exception"]) { raise "lolwut" }
+        end
+        expected_message = "foobar:0|ms|#foo:exception"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
+
       server.close
     end
   end

--- a/src/statsd/methods.cr
+++ b/src/statsd/methods.cr
@@ -57,9 +57,11 @@ module Statsd
     # Measure execution time of a given block, using {#timing}.
     def time(metric_name, tags = nil)
       start = Time.now
-      result = yield
-      timing(metric_name, ((Time.now - start) * 1000).to_i, tags: tags)
-      result
+      yield
+    ensure
+      if start
+        timing(metric_name, ((Time.now - start) * 1000).to_i, tags: tags)
+      end
     end
 
     # Sets


### PR DESCRIPTION
In the event of a yield raising, we never get timings. Wrapping in
`ensure` should emit the timing no matter what.

Hat-tip to @kostya !

Closes #2
