### PR TITLE
:zap: Change input to an actual IPAddress string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project aims to adhere to [Semantic Versioning](http://semver.org/).
 
 # 0.2.0 / Unreleased
 
+- **Breaking** Crystal 0.20.3 stopped automatic client hostname resolution, requiring a full IP address
 - Feature: Emit timing from a block even if raised
 - (Internal) Update MetricMessage to support Crystal 0.16.0
 - (Internal) Replace MetricMessage struct creation with serializer

--- a/spec/statsd/client_spec.cr
+++ b/spec/statsd/client_spec.cr
@@ -3,8 +3,8 @@ require "../spec_helper"
 describe Statsd::Client do
   describe "#initialize" do
     it "should set the host and port" do
-      statsd = Statsd::Client.new("localhost", 1234)
-      statsd.host.should eq "localhost"
+      statsd = Statsd::Client.new("127.0.0.1", 1234)
+      statsd.host.should eq "127.0.0.1"
       statsd.port.should eq 1234
     end
 
@@ -25,11 +25,6 @@ describe Statsd::Client do
       statsd.port.should eq 5678
     end
 
-    it "should not resolve hostnames to IPs" do
-      statsd.host = "localhost"
-      statsd.host.should eq "localhost"
-    end
-
     it "should set nil host to default" do
       statsd.host = nil
       statsd.host.should eq "127.0.0.1"
@@ -48,7 +43,7 @@ describe Statsd::Client do
 
   describe "no server" do
     it "sends messages when nodoby is listening" do
-      statsd = Statsd::Client.new(host: "localhost", port: 1234)
+      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
       5.times do
         statsd.increment "foobar"

--- a/spec/statsd/methods_spec.cr
+++ b/spec/statsd/methods_spec.cr
@@ -5,7 +5,7 @@ describe Statsd::Methods do
     server = UDPSocket.new
     server.bind("localhost", 1234)
 
-    statsd = Statsd::Client.new(host: "localhost", port: 1234)
+    statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
     it "should format the message according to the statsd spec" do
       statsd.gauge("foobar", 20)
@@ -43,7 +43,7 @@ describe Statsd::Methods do
       server = UDPSocket.new
       server.bind("localhost", 1234)
 
-      statsd = Statsd::Client.new(host: "localhost", port: 1234)
+      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
       it "should format the message according to the statsd spec" do
         statsd.increment("foobar")
@@ -78,7 +78,7 @@ describe Statsd::Methods do
       server = UDPSocket.new
       server.bind("localhost", 1234)
 
-      statsd = Statsd::Client.new(host: "localhost", port: 1234)
+      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
       it "should format the message according to the statsd spec" do
         statsd.decrement("foobar")
@@ -113,9 +113,9 @@ describe Statsd::Methods do
   context "timers" do
     describe "#timing" do
       server = UDPSocket.new
-      server.bind("localhost", 1234)
+      server.bind("127.0.0.1", 1234)
 
-      statsd = Statsd::Client.new(host: "localhost", port: 1234)
+      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
       it "should format the message according to the statsd spec" do
         statsd.timing("foobar", 500)
@@ -138,9 +138,9 @@ describe Statsd::Methods do
 
     describe "#time" do
       server = UDPSocket.new
-      server.bind("localhost", 1234)
+      server.bind("127.0.0.1", 1234)
 
-      statsd = Statsd::Client.new(host: "localhost", port: 1234)
+      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
       it "should format the message according to the statsd spec" do
         statsd.time("foobar") { "test" }
@@ -168,9 +168,9 @@ describe Statsd::Methods do
 
   describe "#set" do
     server = UDPSocket.new
-    server.bind("localhost", 1234)
+    server.bind("127.0.0.1", 1234)
 
-    statsd = Statsd::Client.new(host: "localhost", port: 1234)
+    statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
     it "should format the message according to the statsd spec" do
       statsd.set("foobar", 1)
@@ -189,9 +189,9 @@ describe Statsd::Methods do
 
   describe "#histogram" do
     server = UDPSocket.new
-    server.bind("localhost", 1234)
+    server.bind("127.0.0.1", 1234)
 
-    statsd = Statsd::Client.new(host: "localhost", port: 1234)
+    statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
 
     it "should format the message according to the statsd spec" do
       statsd.histogram("foobar", 50)

--- a/src/statsd/client.cr
+++ b/src/statsd/client.cr
@@ -9,7 +9,7 @@ module Statsd
 
     def initialize(@host = "127.0.0.1", @port = 8125)
       @client = UDPSocket.new
-      @destination = Socket::IPAddress.new(Socket::Family::INET, @host, @port)
+      @destination = Socket::IPAddress.new(@host, @port)
     end
 
     getter :host, :port


### PR DESCRIPTION
A change signature of IPAddress Crystal 0.20.3 made the automatic lookup
of hostname to ip invalid.

Instead of complicating our client to further perform DNS lookups, we
only accept an IP address, deferring it to the client to perform the
lookup prior to instantiating a Client.

Resolves #5

Signed-off-by: Mike Fiedler <miketheman@gmail.com>