### PR TITLE
Update for Crystal v0.33 API

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: statsd
-version: 0.1.0
+version: 0.2.0
 
 authors:
   - Mike Fiedler <miketheman@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,6 @@ version: 0.1.0
 authors:
   - Mike Fiedler <miketheman@gmail.com>
 
+crystal: 0.32.0
+
 license: MIT

--- a/spec/statsd/methods_spec.cr
+++ b/spec/statsd/methods_spec.cr
@@ -1,214 +1,225 @@
 require "../spec_helper"
 
+private def with_server(& : UDPSocket, Statsd::Client ->)
+  server = UDPSocket.new
+  server.bind("localhost", 1234)
+
+  statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
+
+  yield server, statsd
+
+ensure
+  server.close if server
+end
+
 describe Statsd::Methods do
   describe "#gauge" do
-    server = UDPSocket.new
-    server.bind("localhost", 1234)
-
-    statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
     it "should format the message according to the statsd spec" do
-      statsd.gauge("foobar", 20)
-      expected_message = "foobar:20|g"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.gauge("foobar", 20)
+        expected_message = "foobar:20|g"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
 
     it "should allow a zero value" do
-      statsd.gauge("foobar", 0)
-      expected_message = "foobar:0|g"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.gauge("foobar", 0)
+        expected_message = "foobar:0|g"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
 
     it "should allow a UInt64 value" do
-      statsd.gauge("foobar", 18446744073709551615)
-      expected_message = "foobar:18446744073709551615|g"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.gauge("foobar", 18446744073709551615)
+        expected_message = "foobar:18446744073709551615|g"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
 
     it "should raise an exception for negative values" do
-      expect_raises(Exception) { statsd.gauge("foobar", -1) }
+      with_server do |server, statsd|
+        expect_raises(Exception) { statsd.gauge("foobar", -1) }
+      end
     end
 
     it "should format the message according to the extended statsd spec" do
-      statsd.gauge("foobar", 20, tags: ["foo:bar"])
-      expected_message = "foobar:20|g|#foo:bar"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.gauge("foobar", 20, tags: ["foo:bar"])
+        expected_message = "foobar:20|g|#foo:bar"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
-
-    server.close
   end
 
   context "counts" do
     describe "#increment" do
-      server = UDPSocket.new
-      server.bind("localhost", 1234)
-
-      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
       it "should format the message according to the statsd spec" do
-        statsd.increment("foobar")
-        expected_message = "foobar:1|c"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.increment("foobar")
+          expected_message = "foobar:1|c"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       it "should format the message according to the extended statsd spec" do
-        statsd.increment("foobar", tags: ["foo:bar"])
-        expected_message = "foobar:1|c|#foo:bar"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.increment("foobar", tags: ["foo:bar"])
+          expected_message = "foobar:1|c|#foo:bar"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       describe "with a sample rate" do
         it "should format the message according to the statsd spec" do
-          statsd.increment("foobar", 0.5)
-          expected_message = "foobar:1|c|@0.5"
-          server.gets(expected_message.bytesize).should eq expected_message
+          with_server do |server, statsd|
+            statsd.increment("foobar", 0.5)
+            expected_message = "foobar:1|c|@0.5"
+            server.gets(expected_message.bytesize).should eq expected_message
+          end
         end
 
         it "should format the message according to the extended statsd spec" do
-          statsd.increment("foobar", 0.5, tags: ["foo:bar"])
-          expected_message = "foobar:1|c|@0.5|#foo:bar"
-          server.gets(expected_message.bytesize).should eq expected_message
+          with_server do |server, statsd|
+            statsd.increment("foobar", 0.5, tags: ["foo:bar"])
+            expected_message = "foobar:1|c|@0.5|#foo:bar"
+            server.gets(expected_message.bytesize).should eq expected_message
+          end
         end
       end
-
-      server.close
     end
 
     describe "#decrement" do
-      server = UDPSocket.new
-      server.bind("localhost", 1234)
-
-      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
       it "should format the message according to the statsd spec" do
-        statsd.decrement("foobar")
-        expected_message = "foobar:-1|c"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.decrement("foobar")
+          expected_message = "foobar:-1|c"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       it "should format the message according to the extended statsd spec" do
-        statsd.decrement("foobar", tags: ["foo:bar"])
-        expected_message = "foobar:-1|c|#foo:bar"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.decrement("foobar", tags: ["foo:bar"])
+          expected_message = "foobar:-1|c|#foo:bar"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       describe "with a sample rate" do
         it "should format the message according to the statsd spec" do
-          statsd.decrement("foobar", 0.5)
-          expected_message = "foobar:-1|c|@0.5"
-          server.gets(expected_message.bytesize).should eq expected_message
+          with_server do |server, statsd|
+            statsd.decrement("foobar", 0.5)
+            expected_message = "foobar:-1|c|@0.5"
+            server.gets(expected_message.bytesize).should eq expected_message
+          end
         end
 
         it "should format the message according to the extended statsd spec" do
-          statsd.decrement("foobar", 0.5, tags: ["foo:bar"])
-          expected_message = "foobar:-1|c|@0.5|#foo:bar"
-          server.gets(expected_message.bytesize).should eq expected_message
+          with_server do |server, statsd|
+            statsd.decrement("foobar", 0.5, tags: ["foo:bar"])
+            expected_message = "foobar:-1|c|@0.5|#foo:bar"
+            server.gets(expected_message.bytesize).should eq expected_message
+          end
         end
       end
-
-      server.close
     end
   end
 
   context "timers" do
     describe "#timing" do
-      server = UDPSocket.new
-      server.bind("127.0.0.1", 1234)
-
-      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
       it "should format the message according to the statsd spec" do
-        statsd.timing("foobar", 500)
-        expected_message = "foobar:500|ms"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.timing("foobar", 500)
+          expected_message = "foobar:500|ms"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       it "should raise an exception for negative values" do
-        expect_raises(Exception) { statsd.timing("foobar", -500) }
+        with_server do |server, statsd|
+          expect_raises(Exception) { statsd.timing("foobar", -500) }
+        end
       end
 
       it "should format the message according to the extended statsd spec" do
-        statsd.timing("foobar", 500, tags: ["foo:bar"])
-        expected_message = "foobar:500|ms|#foo:bar"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.timing("foobar", 500, tags: ["foo:bar"])
+          expected_message = "foobar:500|ms|#foo:bar"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
-
-      server.close
     end
 
     describe "#time" do
-      server = UDPSocket.new
-      server.bind("127.0.0.1", 1234)
-
-      statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
       it "should format the message according to the statsd spec" do
-        statsd.time("foobar") { "test" }
-        expected_message = "foobar:0|ms"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.time("foobar") { "test" }
+          expected_message = "foobar:0|ms"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       it "should format the message according to the extended statsd spec" do
-        statsd.time("foobar", tags: ["foo:bar"]) { "test" }
-        expected_message = "foobar:0|ms|#foo:bar"
-        server.gets(expected_message.bytesize).should eq expected_message
+        with_server do |server, statsd|
+          statsd.time("foobar", tags: ["foo:bar"]) { "test" }
+          expected_message = "foobar:0|ms|#foo:bar"
+          server.gets(expected_message.bytesize).should eq expected_message
+        end
       end
 
       it "should emit a timing even if the block raises" do
-        expect_raises(Exception) do
-          statsd.time("foobar", tags: ["foo:exception"]) { raise "lolwut" }
+        with_server do |server, statsd|
+          expect_raises(Exception) do
+            statsd.time("foobar", tags: ["foo:exception"]) { raise "lolwut" }
+          end
+          expected_message = "foobar:0|ms|#foo:exception"
+          server.gets(expected_message.bytesize).should eq expected_message
         end
-        expected_message = "foobar:0|ms|#foo:exception"
-        server.gets(expected_message.bytesize).should eq expected_message
       end
-
-      server.close
     end
   end
 
   describe "#set" do
-    server = UDPSocket.new
-    server.bind("127.0.0.1", 1234)
-
-    statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
     it "should format the message according to the statsd spec" do
-      statsd.set("foobar", 1)
-      expected_message = "foobar:1|s"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.set("foobar", 1)
+        expected_message = "foobar:1|s"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
 
     it "should format the message according to the extended statsd spec" do
-      statsd.set("foobar", 1, tags: ["foo:bar"])
-      expected_message = "foobar:1|s|#foo:bar"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.set("foobar", 1, tags: ["foo:bar"])
+        expected_message = "foobar:1|s|#foo:bar"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
-
-    server.close
   end
 
   describe "#histogram" do
-    server = UDPSocket.new
-    server.bind("127.0.0.1", 1234)
-
-    statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)
-
     it "should format the message according to the statsd spec" do
-      statsd.histogram("foobar", 50)
-      expected_message = "foobar:50|h"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.histogram("foobar", 50)
+        expected_message = "foobar:50|h"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
 
     it "should raise an exception for negative values" do
-      expect_raises(Exception) { statsd.histogram("foobar", -50) }
+      with_server do |server, statsd|
+        expect_raises(Exception) { statsd.histogram("foobar", -50) }
+      end
     end
 
     it "should format the message according to the extended statsd spec" do
-      statsd.histogram("foobar", 50, tags: ["foo:bar"])
-      expected_message = "foobar:50|h|#foo:bar"
-      server.gets(expected_message.bytesize).should eq expected_message
+      with_server do |server, statsd|
+        statsd.histogram("foobar", 50, tags: ["foo:bar"])
+        expected_message = "foobar:50|h|#foo:bar"
+        server.gets(expected_message.bytesize).should eq expected_message
+      end
     end
-
-    server.close
   end
 end

--- a/src/statsd/methods.cr
+++ b/src/statsd/methods.cr
@@ -60,7 +60,7 @@ module Statsd
       yield
     ensure
       if start
-        timing(metric_name, (Time.monotonic - start).total_milliseconds, tags: tags)
+        timing(metric_name, (Time.monotonic - start).total_milliseconds.to_i, tags: tags)
       end
     end
 

--- a/src/statsd/methods.cr
+++ b/src/statsd/methods.cr
@@ -56,11 +56,11 @@ module Statsd
 
     # Measure execution time of a given block, using {#timing}.
     def time(metric_name, tags = nil)
-      start = Time.now
+      start = Time.monotonic
       yield
     ensure
       if start
-        timing(metric_name, ((Time.now - start) * 1000).to_i, tags: tags)
+        timing(metric_name, (Time.monotonic - start).total_milliseconds, tags: tags)
       end
     end
 


### PR DESCRIPTION
`Time.now` has been removed in Crystal 0.33 and the new standard is to use `Time.utc` or `Time.local` in its place.

However, I feel like this should probably actually be using a monotonic clock, so I've switched it to use `Time.monotonic` instead.