### PR TITLE
chore(ci): replace travis with github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-sudo: required
-dist: trusty
-language: crystal

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A [statsd](https://github.com/etsy/statsd) client library for [Crystal](http://crystal-lang.org/).
 
-[![Build Status](https://travis-ci.org/miketheman/statsd.cr.svg?branch=master)](https://travis-ci.org/miketheman/statsd.cr)
-[![crystal-docs.org](https://crystal-docs.org/badge.svg)](https://crystal-docs.org/miketheman/statsd.cr)
+![Crystal CI](https://github.com/miketheman/statsd.cr/workflows/Crystal%20CI/badge.svg)
 
 ## Installation
 


### PR DESCRIPTION
Removes incorrect docs link and adds new badge.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>