### PR TITLE
Client constructor

### DIFF
--- a/spec/statsd/client_spec.cr
+++ b/spec/statsd/client_spec.cr
@@ -15,32 +15,6 @@ describe Statsd::Client do
     end
   end
 
-  describe "#host and #port" do
-    statsd = Statsd::Client.new
-
-    it "should set host and port" do
-      statsd.host = "1.2.3.4"
-      statsd.port = 5678
-      statsd.host.should eq "1.2.3.4"
-      statsd.port.should eq 5678
-    end
-
-    it "should set nil host to default" do
-      statsd.host = nil
-      statsd.host.should eq "127.0.0.1"
-    end
-
-    it "should set nil port to default" do
-      statsd.port = nil
-      statsd.port.should eq 8125
-    end
-
-    it "should allow an IPv6 address" do
-      statsd.host = "::1"
-      statsd.host.should eq "::1"
-    end
-  end
-
   describe "no server" do
     it "sends messages when nodoby is listening" do
       statsd = Statsd::Client.new(host: "127.0.0.1", port: 1234)

--- a/spec/statsd/client_spec.cr
+++ b/spec/statsd/client_spec.cr
@@ -13,6 +13,12 @@ describe Statsd::Client do
       statsd.host.should eq "127.0.0.1"
       statsd.port.should eq 8125
     end
+
+    it "accepts an IPAddress" do
+      statsd = Statsd::Client.new Socket::IPAddress.new("127.0.0.2", 2345)
+      statsd.host.should eq "127.0.0.2"
+      statsd.port.should eq 2345
+    end
   end
 
   describe "no server" do

--- a/src/statsd/client.cr
+++ b/src/statsd/client.cr
@@ -6,21 +6,21 @@ module Statsd
   class Client
     include Methods
 
-    def initialize(@host = "127.0.0.1", @port = 8125)
+    def self.new(host : String = "127.0.0.1", port : Int = 8125)
+      new(Socket::IPAddress.new(host, port))
+    end
+
+    def initialize(@destination = Socket::IPAddress.new("127.0.0.1", 8125))
       @client = UDPSocket.new
-      @destination = Socket::IPAddress.new(@host, @port)
+      @client.connect @destination
     end
 
-    getter :host, :port
-
-    # StatsD host. Defaults to 127.0.0.1.
-    def host=(host)
-      @host = host || "127.0.0.1"
+    def host
+      @destination.address
     end
 
-    # StatsD port. Defaults to 8125.
-    def port=(port)
-      @port = port || 8125
+    def port
+      @destination.port
     end
 
     private def send_metric(name, value, metric_type, sample_rate = nil, tags = nil)
@@ -32,7 +32,7 @@ module Statsd
         tags)
 
       begin
-        @client.send(message, @destination)
+        @client.send(message)
       rescue ex : IO::Error
       end
     end

--- a/src/statsd/client.cr
+++ b/src/statsd/client.cr
@@ -12,7 +12,6 @@ module Statsd
 
     def initialize(@destination = Socket::IPAddress.new("127.0.0.1", 8125))
       @client = UDPSocket.new
-      @client.connect @destination
     end
 
     def host
@@ -32,7 +31,7 @@ module Statsd
         tags)
 
       begin
-        @client.send(message)
+        @client.send(message, @destination)
       rescue ex : IO::Error
       end
     end

--- a/src/statsd/client.cr
+++ b/src/statsd/client.cr
@@ -6,7 +6,7 @@ module Statsd
   class Client
     include Methods
 
-    def self.new(host : String = "127.0.0.1", port : Int = 8125)
+    def self.new(host : String, port : Int)
       new(Socket::IPAddress.new(host, port))
     end
 


### PR DESCRIPTION
Allow users of the lib to pass an `IPAddress` directly to the client without having to convert back and forth. 